### PR TITLE
Producer#CreateMessage: Separate from struct and use []byte values

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ go func() {
 }()
 
 strTime := strconv.Itoa(int(time.Now().Unix()))
-msg := asyncProducer.CreateKeyMessage("test", strTime, "testValue")
+msg := producer.CreateKeyMessage("test", strTime, []byte("testValue"))
 
 input, _ := asyncProducer.Input()
 input <- msg // Produce message

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -68,25 +68,6 @@ func (p *Producer) EnableLogging() {
 	p.isLoggingEnabled = true
 }
 
-// CreateKeyMessage creates producer-formatted message with key
-func (p *Producer) CreateKeyMessage(topic string, key string, value string) *sarama.ProducerMessage {
-	msg := &sarama.ProducerMessage{
-		Topic: topic,
-		Value: sarama.StringEncoder(value),
-	}
-
-	if key != "" {
-		msg.Key = sarama.StringEncoder(key)
-	}
-
-	return msg
-}
-
-// CreateMessage creates keyless producer-formatted message
-func (p *Producer) CreateMessage(topic string, value string) *sarama.ProducerMessage {
-	return p.CreateKeyMessage(topic, "", value)
-}
-
 // IsClosed returns a bool specifying if Kafka producer is closed
 func (p *Producer) IsClosed() bool {
 	return p.isClosed

--- a/producer/producerutils.go
+++ b/producer/producerutils.go
@@ -1,0 +1,22 @@
+package producer
+
+import "github.com/Shopify/sarama"
+
+// CreateKeyMessage creates producer-formatted message with key
+func CreateKeyMessage(topic string, key string, value []byte) *sarama.ProducerMessage {
+	msg := &sarama.ProducerMessage{
+		Topic: topic,
+		Value: sarama.ByteEncoder(value),
+	}
+
+	if key != "" {
+		msg.Key = sarama.StringEncoder(key)
+	}
+
+	return msg
+}
+
+// CreateMessage creates keyless producer-formatted message
+func CreateMessage(topic string, value []byte) *sarama.ProducerMessage {
+	return CreateKeyMessage(topic, "", value)
+}


### PR DESCRIPTION
It was noted that most of the values being produced were already of type `[]byte`. This meant they had to be converted to string to be used for `producer#CreateMessage` function.

Since Sarama itself converts string to byte-array in StringEncoder, this meant us doing needless conversions (convert []byte to string, and then Sarama converts string to []byte).

So from now, we'll be accepting []byte values for generating messages. The message-key and topic are still in string.